### PR TITLE
chore/refatoracao-modulos-docs

### DIFF
--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.3.0
+          terraform_version: 1.9.5
 
       - name: Terraform Init
         run: terraform init  # Executa terraform init na raiz do projeto

--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -17,7 +17,7 @@ jobs:
 
     # Definir as credenciais da AWS com base no ambiente (dev ou prod)
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2"></a> [ec2](#module\_ec2) | github.com/descomplicando-terraform/terraform-aws-Diego-Rafael_groundwork/ec2 | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/descomplicando-terraform/terraform-aws-Diego-Rafael_groundwork/vpc | n/a |
+| <a name="module_groundwork"></a> [groundwork](#module\_groundwork) | ../terraform-aws-Diego-Rafael_groundwork | n/a |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "groundwork" {
-  source                = "../terraform-aws-Diego-Rafael_groundwork"
+  source                = "github.com/descomplicando-terraform/terraform-aws-Diego-Rafael_groundwork"
   vpc_cidr_block        = "192.168.3.0/24"
   subnets_map           = module.groundwork.subnets_map
   instance_name_prefix  = "docker"

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,7 @@
-module "vpc" {
-  source         = "github.com/descomplicando-terraform/terraform-aws-Diego-Rafael_groundwork/vpc"
-  vpc_cidr_block = "192.168.3.0/24"
-}
-
-module "ec2" {
-  source                = "github.com/descomplicando-terraform/terraform-aws-Diego-Rafael_groundwork/ec2"
-  subnets_map           = module.vpc.subnets_map
-  vpc_terraform         = module.vpc.vpc_terraform
+module "groundwork" {
+  source                = "../terraform-aws-Diego-Rafael_groundwork"
+  vpc_cidr_block        = "192.168.3.0/24"
+  subnets_map           = module.groundwork.subnets_map
   instance_name_prefix  = "docker"
   instance_docker_count = 2
   instance_type         = "t2.nano"

--- a/provider.tf
+++ b/provider.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.9.0"
+  required_version = ">= 1.9.5"
 }
 
 # Configure the AWS Provider

--- a/provider.tf
+++ b/provider.tf
@@ -5,9 +5,17 @@ terraform {
       version = "~> 5.0"
     }
   }
+  required_version = ">= 1.9.5"
 }
 
 # Configure the AWS Provider
 provider "aws" {
   region = "us-east-1"
+  default_tags {
+    tags = {
+      Owner     = "diegodrk"
+      ManagedBy = "terraform"
+      Project   = "https://github.com/descomplicando-terraform/terraform-aws-Diego-Rafael_produto/"
+    }
+  }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.9.5"
+  required_version = ">= 1.9.0"
 }
 
 # Configure the AWS Provider


### PR DESCRIPTION
**Unificação dos módulos ec2 e vpc**
- Os recursos e suas variáveis agora estão presente dentro de um único diretório
- Não há mais necessidade de chamar dois módulos no repositório de produtos

**Remoção de variáveis desnecessárias**
- A variável vpc_terraform foi removida para utilização do id do recurso vpc-terraform criado na sessão aws_vpc

**Ajuste da documentação**
- Atualizado o README.md para atualização do mapeamento

**Ajustado workflow GitHub Actions**
- Ajustada a versão requerida no providers.tf e workflow do terraform plan
- Ajustado o tipo de variável para execução do pipeline terraform para correção de falha na execução

**Ajuste de tags default**
- Criadas as Tags Default do projeto para serem herdadas pelos recursos a serem criados