### PR TITLE
feat/add-private-subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ No resources.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create_private_subnets"></a> [create\_private\_subnets](#input\_create\_private\_subnets) | Flag to create private subnets | `bool` | `false` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -11,4 +11,5 @@ module "groundwork" {
       volume_size_docker = 10
     }
   ]
+  create_private_subnets = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,10 @@
+variable "create_private_subnets" {
+  description = "Flag to create private subnets"
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = can(var.create_private_subnets)
+    error_message = "A variável 'create_private_subnets' precisa de um valor booleano (true ou false)."
+  }
+}


### PR DESCRIPTION
**Criação de sub-redes privadas**
- Agora é possível escolher cirar sub-redes privadas na VPC
- Ao definir a flag create_private_subnets = true, serão criadas as Subnets privadas previamente definidas no groundwork
- Após criadas, automaticamente as rotas serão associadas a estas Subnets

